### PR TITLE
Handle non-JSON SSE events

### DIFF
--- a/frontend/src/views/chat/answer/AnalysisAnswer.vue
+++ b/frontend/src/views/chat/answer/AnalysisAnswer.vue
@@ -125,12 +125,17 @@ const sendMessage = async () => {
       tempResult = events.pop() || ''
       for (const evt of events) {
         if (!evt.startsWith('data:')) continue
+        const jsonStr = evt.slice(5).trim()
+        if (!jsonStr.startsWith('{')) {
+          console.error('Non-JSON SSE event:', jsonStr)
+          continue
+        }
         let data
         try {
-          data = JSON.parse(evt.slice(5))
+          data = JSON.parse(jsonStr)
         } catch (err) {
-          console.error('JSON string:', evt)
-          throw err
+          console.error('JSON string:', jsonStr, err)
+          continue
         }
 
         if (data.code && data.code !== 200) {

--- a/frontend/src/views/chat/answer/ChartAnswer.vue
+++ b/frontend/src/views/chat/answer/ChartAnswer.vue
@@ -130,12 +130,17 @@ const sendMessage = async () => {
       tempResult = events.pop() || ''
       for (const evt of events) {
         if (!evt.startsWith('data:')) continue
+        const jsonStr = evt.slice(5).trim()
+        if (!jsonStr.startsWith('{')) {
+          console.error('Non-JSON SSE event:', jsonStr)
+          continue
+        }
         let data
         try {
-          data = JSON.parse(evt.slice(5))
+          data = JSON.parse(jsonStr)
         } catch (err) {
-          console.error('JSON string:', evt)
-          throw err
+          console.error('JSON string:', jsonStr, err)
+          continue
         }
 
         if (data.code && data.code !== 200) {

--- a/frontend/src/views/chat/answer/PredictAnswer.vue
+++ b/frontend/src/views/chat/answer/PredictAnswer.vue
@@ -126,12 +126,17 @@ const sendMessage = async () => {
       tempResult = events.pop() || ''
       for (const evt of events) {
         if (!evt.startsWith('data:')) continue
+        const jsonStr = evt.slice(5).trim()
+        if (!jsonStr.startsWith('{')) {
+          console.error('Non-JSON SSE event:', jsonStr)
+          continue
+        }
         let data
         try {
-          data = JSON.parse(evt.slice(5))
+          data = JSON.parse(jsonStr)
         } catch (err) {
-          console.error('JSON string:', evt)
-          throw err
+          console.error('JSON string:', jsonStr, err)
+          continue
         }
 
         if (data.code && data.code !== 200) {


### PR DESCRIPTION
## Summary
- avoid parsing non-JSON SSE messages in chat answer components to prevent `Unexpected token` errors

## Testing
- `npm run lint` *(fails: Layout is defined but never used in src/router/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a31f3161b48320940c87729caedf55