### PR TITLE
feat: 添加 K8s 本地部署清单 (deploy/k8s-local)

### DIFF
--- a/deploy/k8s-local/README.md
+++ b/deploy/k8s-local/README.md
@@ -1,0 +1,84 @@
+# SQLBot 本地 K8s 部署（镜像 zf-sqlbot:latest）
+
+使用本地镜像 `zf-sqlbot:latest` 在 Kubernetes 中运行 SQLBot。
+
+## 前置条件
+
+- 可用的 Kubernetes 集群（`kubectl get nodes` 能列出节点）
+- 集群能使用镜像 `zf-sqlbot:latest`：
+  - **单节点本机集群**：需把镜像导入集群（见下方「镜像准备」）
+  - **多节点或远程集群**：建议将镜像推送到集群可访问的镜像仓库，并修改 `deployment.yaml` 中的 `image`
+
+## 镜像准备（本机单节点集群）
+
+若集群跑在本机且使用 containerd（如 Sealos），本机 Docker 的镜像不会自动可见，可二选一：
+
+1. **推送到可访问的镜像仓库**  
+   给镜像打 tag 并 push，然后在 deployment 里把 `image` 改成该仓库地址。
+
+2. **导入到 containerd（本机节点）**  
+   ```bash
+   docker save zf-sqlbot:latest | sudo ctr -n k8s.io images import -
+   ```
+
+## 部署步骤
+
+### 方式 A：使用 PVC（数据持久化）
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f configmap.yaml
+kubectl apply -f secret.yaml
+kubectl apply -f pvc.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+```
+
+需要集群有默认 StorageClass，否则 PVC 会一直 Pending。
+
+### 方式 B：不使用 PVC（快速测试，数据不持久化）
+
+不创建 PVC，改用 emptyDir 的 Deployment：
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f configmap.yaml
+kubectl apply -f secret.yaml
+kubectl apply -f deployment-no-pvc.yaml
+kubectl apply -f service.yaml
+```
+
+## 访问服务
+
+Service 类型为 NodePort：
+
+- **API**：`http://<节点IP>:30080`
+- **MCP**：`<节点IP>:30081`
+
+本机单节点可用：
+
+- `http://localhost:30080`
+- `localhost:30081`
+
+## 常用命令
+
+```bash
+# 查看 Pod
+kubectl get pods -n sqlbot -o wide
+
+# 查看日志
+kubectl logs -f deployment/sqlbot -n sqlbot
+
+# 删除部署
+kubectl delete -f service.yaml -f deployment.yaml -f pvc.yaml -f secret.yaml -f configmap.yaml -f namespace.yaml
+# 若用的是无 PVC 版本：
+kubectl delete -f service.yaml -f deployment-no-pvc.yaml -f secret.yaml -f configmap.yaml -f namespace.yaml
+```
+
+## 当前环境说明
+
+- **kubectl / kubelet / kubeadm / sealos** 已安装。
+- **当前 kubeconfig** 指向 `apiserver.cluster.local:6443`（解析为 192.168.1.18），若该机器未启动或网络不通，`kubectl get nodes` 会超时。
+- 若要用 **Sealos 单节点** 在本机起集群，需保证本机 SSH 可用，并指定 master 为本机 IP，例如：  
+  `sealos run labring/kubernetes:v1.24.0 --masters $(hostname -I | awk '{print $1}')`  
+  集群起来后，再按上述步骤部署，并按要求准备 `zf-sqlbot:latest` 镜像。

--- a/deploy/k8s-local/configmap.yaml
+++ b/deploy/k8s-local/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sqlbot-config
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+data:
+  PROJECT_NAME: "SQLBot"
+  POSTGRES_SERVER: "localhost"
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: "sqlbot"
+  POSTGRES_USER: "root"
+  DEFAULT_PWD: "SQLBot@123456"
+  BACKEND_CORS_ORIGINS: "http://localhost,http://localhost:5173,https://localhost,https://localhost:5173"
+  SERVER_IMAGE_HOST: "http://YOUR_SERVE_IP:8001/images/"
+  LOG_LEVEL: "INFO"
+  SQL_DEBUG: "false"
+  CACHE_TYPE: "memory"
+  ACCESS_TOKEN_EXPIRE_MINUTES: "11520"

--- a/deploy/k8s-local/deployment-no-pvc.yaml
+++ b/deploy/k8s-local/deployment-no-pvc.yaml
@@ -1,0 +1,75 @@
+# 无 PVC 版本：使用 emptyDir，适合无默认 StorageClass 或快速测试（数据不持久化）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sqlbot
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sqlbot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sqlbot
+    spec:
+      containers:
+        - name: sqlbot
+          image: zf-sqlbot:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: api
+              containerPort: 8000
+              protocol: TCP
+            - name: mcp
+              containerPort: 8001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: sqlbot-config
+            - secretRef:
+                name: sqlbot-secret
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /var/lib/postgresql/data
+            - name: data
+              mountPath: /opt/sqlbot/data
+            - name: images
+              mountPath: /opt/sqlbot/images
+            - name: logs
+              mountPath: /opt/sqlbot/app/logs
+          livenessProbe:
+            httpGet:
+              path: /openapi.json
+              port: api
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /openapi.json
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "2000m"
+      volumes:
+        - name: postgresql-data
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+        - name: images
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}

--- a/deploy/k8s-local/deployment.yaml
+++ b/deploy/k8s-local/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sqlbot
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sqlbot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sqlbot
+    spec:
+      containers:
+        - name: sqlbot
+          image: zf-sqlbot:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: api
+              containerPort: 8000
+              protocol: TCP
+            - name: mcp
+              containerPort: 8001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: sqlbot-config
+            - secretRef:
+                name: sqlbot-secret
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /var/lib/postgresql/data
+            - name: data
+              mountPath: /opt/sqlbot/data
+            - name: images
+              mountPath: /opt/sqlbot/images
+            - name: logs
+              mountPath: /opt/sqlbot/app/logs
+          livenessProbe:
+            httpGet:
+              path: /openapi.json
+              port: api
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /openapi.json
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "2000m"
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: sqlbot-postgresql
+        - name: data
+          persistentVolumeClaim:
+            claimName: sqlbot-data
+        - name: images
+          persistentVolumeClaim:
+            claimName: sqlbot-images
+        - name: logs
+          persistentVolumeClaim:
+            claimName: sqlbot-logs

--- a/deploy/k8s-local/namespace.yaml
+++ b/deploy/k8s-local/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot

--- a/deploy/k8s-local/pvc.yaml
+++ b/deploy/k8s-local/pvc.yaml
@@ -1,0 +1,56 @@
+# 若集群无默认 StorageClass 或仅想快速测试，可在 deployment 中改用 emptyDir，不 apply 本文件
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sqlbot-postgresql
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sqlbot-data
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sqlbot-images
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sqlbot-logs
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/deploy/k8s-local/secret.yaml
+++ b/deploy/k8s-local/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sqlbot-secret
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: "Password123@pg"
+  SECRET_KEY: "y5txe1mRmS_JpOrUzFzHEu-kIQn3lf7ll0AOv9DQh0s"

--- a/deploy/k8s-local/service.yaml
+++ b/deploy/k8s-local/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqlbot
+  namespace: sqlbot
+  labels:
+    app.kubernetes.io/name: sqlbot
+spec:
+  type: NodePort
+  ports:
+    - port: 8000
+      targetPort: api
+      nodePort: 30080
+      protocol: TCP
+      name: api
+    - port: 8001
+      targetPort: mcp
+      nodePort: 30081
+      protocol: TCP
+      name: mcp
+  selector:
+    app.kubernetes.io/name: sqlbot


### PR DESCRIPTION
- 使用镜像 zf-sqlbot:latest，支持 Kind 集群
- 含 namespace/configmap/secret/pvc/deployment/service
- 提供 deployment-no-pvc 版本便于无 StorageClass 环境
- 补充 README 说明部署步骤与镜像准备

Made-with: Cursor